### PR TITLE
Typo? Need support for 8.2?

### DIFF
--- a/web/src/app/WebApp/Installers/BaseSetup.php
+++ b/web/src/app/WebApp/Installers/BaseSetup.php
@@ -45,8 +45,10 @@ abstract class BaseSetup implements InstallerInterface {
 				"7.1",
 				"7.2",
 				"7.3",
-				"7.4" . "8.0",
+				"7.4",
+				"8.0",
 				"8.1",
+				"8.2",
 			];
 		}
 		return $this->appInfo;


### PR DESCRIPTION
Previously this was formatted horizontally and was less obvious. Why concat in the middle of an array? Looks like a typo. Appended 8.2.
```
$this -> appInfo['php_support'] = array('5.6','7.0','7.1','7.2','7.3','7.4'.'8.0','8.1');
```